### PR TITLE
docs(readme): fix 404 link for `Source Structure`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To clone this repository along with the submodules:
 git clone --recurse-submodules https://github.com/dreamworksanimation/openmoonray.git
 ```
 
-[Source Structure](https://dreamworksanimation.github.io/openmoonray-docs/developers-guide/source-structure/)  
+[Source Structure](https://docs.openmoonray.org/developer-reference/source-structure/)  
 [Building MoonRay](https://dreamworksanimation.github.io/openmoonray-docs/getting-started/installation/building-moonray/)  
 [Documentation](https://dreamworksanimation.github.io/openmoonray-docs/)  
 [Website](https://openmoonray.org/)  


### PR DESCRIPTION
These docs links do not exist at `https://dreamworksanimation.github.io/openmoonray-docs/` anymore, and the `Source Structure` was not correctly redirecting to `docs.openmoonray.org`.

This updates the url to a 200.