### PR TITLE
Fix broken link for Source Structure in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To clone this repository along with the submodules:
 git clone --recurse-submodules https://github.com/dreamworksanimation/openmoonray.git
 ```
 
-[Source Structure](https://dreamworksanimation.github.io/openmoonray-docs/developers-guide/source-structure/)  
+[Source Structure](https://docs.openmoonray.org/developer-reference/source-structure/)  
 [Building MoonRay](https://dreamworksanimation.github.io/openmoonray-docs/getting-started/installation/building-moonray/)  
 [Documentation](https://dreamworksanimation.github.io/openmoonray-docs/)  
 [Website](https://openmoonray.org/)  


### PR DESCRIPTION
Replace incorrect `developers-guide` with correct `developer-reference`.