### PR TITLE
Fix CMake vars for module discovery and install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,12 @@ list(APPEND CMAKE_MESSAGE_CONTEXT ${PROJECT_NAME})
 if(NOT DEFINED CMAKE_INSTALL_PREFIX OR ${CMAKE_INSTALL_PREFIX} STREQUAL "/usr/local")
     set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/release)
 endif()
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/cmake)
 
 # Make sure Cuda's bin directory is in ${PATH} so that check_language can find it.
-set(ENV{PATH} "${CUDAToolkit_ROOT}/bin:$ENV{PATH}")
+if(DEFINED CUDAToolkit_ROOT)
+    set(ENV{PATH} "${CUDAToolkit_ROOT}/bin:$ENV{PATH}")
+endif()
 
 include(CheckLanguage)
 check_language(CUDA)

--- a/arras/CMakeLists.txt
+++ b/arras/CMakeLists.txt
@@ -7,9 +7,6 @@ project(Arras
         VERSION 4.9.0
         LANGUAGES CXX)
 
-set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/../release)
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-
 set(Building_ArrasCore TRUE)
 
 add_subdirectory(arras4_core)

--- a/arras/distributed/CMakeLists.txt
+++ b/arras/distributed/CMakeLists.txt
@@ -7,7 +7,9 @@ project(ArrasDistributed
         VERSION 4.9.0
         LANGUAGES CXX)
 
-set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/../../release)
+if (NOT Building_ArrasCore)
+    set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/../../release)
+endif()
 # set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
 
 # ================================================
@@ -26,7 +28,7 @@ find_package(Boost REQUIRED
 
 # if we aren't building ArrasCore, get it from the release
 if (NOT Building_ArrasCore)
-    set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_INSTALL_PREFIX}/cmake")
+    list(PREPEND CMAKE_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/cmake")
     find_package(ArrasCore REQUIRED)
 endif()
 


### PR DESCRIPTION
Fixes issues with erroneous discovery of Moonray dependencies.

Namely, if the first directory of `$PATH` is set to `/bin` then `/bin`, `/lib` and `/include` would be used as search paths.

```
-- Found Boost: /lib/cmake/Boost-1.81.0/BoostConfig.cmake (found version "1.81.0") found components: chrono date_time filesystem program_options system 
-- Found Boost: /lib/cmake/Boost-1.81.0/BoostConfig.cmake (found version "1.81.0") found components: chrono date_time filesystem program_options 
-- Found Python: /bin/python3.11 (found version "3.11.3") found components: Interpreter
```

But `/include` doesn't exist in your standard Linux install, so CMake is going to look at the wrong place if it were to look for headers.

Also this PR uses `list(PREPEND ...)` with `CMAKE_MODULE_PATH` so that it considers project paths first and `CMAKE_INSTALL_PREFIX` is assigned to the default value of `release` if unset.
