### PR TITLE
Use base image nvidia/cuda:11.4.3-base-centos7

### DIFF
--- a/building/Dockerfile
+++ b/building/Dockerfile
@@ -2,7 +2,7 @@
 # on top of this image, use CMake to install the 
 # additional moonray dependencies.
 
-FROM nvidia/cuda:11.4.0-base-centos7
+FROM nvidia/cuda:11.4.3-base-centos7
 
 RUN yum install -y epel-release centos-release-scl.noarch
 RUN yum install -y devtoolset-9 devtoolset-9-gcc \
@@ -12,7 +12,7 @@ RUN yum install -y bison flex  wget git python3 python3-devel \
                    libatomic libcgroup-devel libuuid-devel \
                    openssl-devel curl-devel
 
-# Not required when using cuda:11.4.0-base-centos7
+# Not required when using cuda:11.4.3-base-centos7
 # RUN yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
 RUN yum install -y mesa-libGL
 RUN yum install -y cuda-toolkit-11-4


### PR DESCRIPTION
Hi all,
I tried to build openmoonray on the container,

but it shows me an error `manifest for nvidia/cuda:11.4.0-base-centos7 not found: manifest unknown: manifest unknown`

so I checked [nvidia:cuda image repo](https://hub.docker.com/r/nvidia/cuda/tags?page=1&name=11.4.0-base-centos7), and it turns out that cuda:11.4.0 was removed from nvidia:cuda. 

the closest version is [nvidia/cuda:11.4.3-base-centos7](https://hub.docker.com/r/nvidia/cuda/tags?page=1&name=11.4.3-base-centos7) and I could built the openmoonray with this image now.

Thank you.