### PR TITLE
Building MoonRay container with Rocky Linux 9 image and Apptainer (formerly Singularity)

### DIFF
--- a/building/Apptainer/build.sh
+++ b/building/Apptainer/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# ===========
+#    Usage
+# ===========
+#
+# export WORKDIR=$(pwd)
+# bash ./openmoonray/building/Apptainer/build.sh
+# 
+
+# Make cache directory and tmp directory
+mkdir -p ${WORKDIR}/.moonray_build_cache
+mkdir -p ${WORKDIR}/.moonray_build_tmp
+export CACHEDIR=${WORKDIR}/.moonray_build_cache
+export TMPDIR=${WORKDIR}/.moonray_build_tmp
+
+# Copy OptiX installer script
+cp ${WORKDIR}/NVIDIA-OptiX-SDK-7.3.0-linux64-x86_64.sh ${WORKDIR}/openmoonray/building/Rocky9/optix.sh
+
+# Build MoonRay container
+cd ${WORKDIR}/openmoonray/building/Apptainer
+apptainer build -B ${WORKDIR}:/workdir ${WORKDIR}/moonray.sif moonray.def
+
+# Build minicoord container
+apptainer build -B ${WORKDIR}:/workdir ${WORKDIR}/minicoord.sif minicoord.def
+
+# Clean up cache directory and tmp directory
+rm -rf ${CACHEDIR}
+rm -rf ${TMPDIR}
+
+cd ${WORKDIR}

--- a/building/Apptainer/minicoord.def
+++ b/building/Apptainer/minicoord.def
@@ -1,0 +1,14 @@
+Bootstrap: docker
+From: python:2.7.18
+
+%setup
+    mkdir -p ${APPTAINER_ROOTFS}/workdir
+
+%files
+    ../../arras/distributed/minicoord/minicoord /
+
+%post
+    pip install tornado==4.5.3 requests==2.27.1
+
+%runscript
+    python -i /minicoord/run.py

--- a/building/Apptainer/moonray.def
+++ b/building/Apptainer/moonray.def
@@ -3,10 +3,10 @@ From: rockylinux/rockylinux:9.2
 
 %setup
     mkdir -p ${APPTAINER_ROOTFS}/source/building
+    mkdir -p ${APPTAINER_ROOTFS}/workdir
 
 %files
-    Rocky9 /source/building
-    NVIDIA-OptiX-SDK-7.3.0-linux64-x86_64.sh /source/building/Rocky9/optix.sh
+    ../Rocky9 /source/building
 
 %post
     # Step 1: Base Requiements
@@ -17,26 +17,26 @@ From: rockylinux/rockylinux:9.2
     cd /build
     cmake /source/building/Rocky9
     cmake --build . -- -j $(nproc)
+    rm -rf /build/*
 
     # Step 2 (optional): Install OptiX
     bash /source/building/Rocky9/optix.sh --prefix=/usr/local --skip-license
 
     # Step 3: Build MoonRay 
     cd /build
-    rm -rf *
-    cd /source
-    git clone -b openmoonray-1.3.0.0 --recurse-submodules https://github.com/dreamworksanimation/openmoonray.git
-    cd /build
-    cmake /source/openmoonray \
+    cmake /workdir/openmoonray \
       -DPYTHON_EXECUTABLE=python3 -DBOOST_PYTHON_COMPONENT_NAME=python39 -DABI_VERSION=0
     cmake --build . -j $(nproc)
     mkdir -p /installs/openmoonray
     cmake --install . --prefix /installs/openmoonray
+    rm -rf /build/*
     
-    # Final Step: Move shader_json directory to writable location
+    # Final Step: Move shader_json directory to writable location and copy testdata
     cd /installs/openmoonray
     sed -i 's@rel_root=${sourcedir}/..@rel_root=/installs/openmoonray@' scripts/setup.sh
     sed -i 's@${rel_root}/shader_json@/tmp/shader_json@' scripts/setup.sh
+    cp -r /workdir/openmoonray/testdata /installs
+
 
 %environment
     export PS1="MoonRay> "
@@ -46,4 +46,4 @@ From: rockylinux/rockylinux:9.2
     export PYTHONPATH=/usr/local/lib/python
     ulimit -n 8192
     source /installs/openmoonray/scripts/setup.sh
-    "$@"
+    bash "$@"

--- a/building/Rocky9/install_packages.sh
+++ b/building/Rocky9/install_packages.sh
@@ -14,11 +14,6 @@ dnf install -y bison flex wget git python3 python3-devel patch \
 
 mkdir -p /installs/{bin,lib,include}
 cd /installs
-wget https://kojihub.stream.centos.org/kojifiles/packages/libcgroup/0.42.2/5.el9/x86_64/libcgroup-0.42.2-5.el9.x86_64.rpm
-wget https://kojihub.stream.centos.org/kojifiles/packages/libcgroup/0.42.2/5.el9/x86_64/libcgroup-devel-0.42.2-5.el9.x86_64.rpm
-dnf install libcgroup-0.42.2-5.el9.x86_64.rpm -y
-dnf install libcgroup-devel-0.42.2-5.el9.x86_64.rpm -y
-
 wget https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-linux-x86_64.tar.gz
 tar xzf cmake-3.23.1-linux-x86_64.tar.gz
 
@@ -32,7 +27,6 @@ dnf install -y cppunit cppunit-devel #1.15.1
 dnf install -y libmicrohttpd libmicrohttpd-devel #0.9.72
 
 dnf install -y qt5-qtbase-devel qt5-qtscript-devel
-
 
 export PATH=/installs/cmake-3.23.1-linux-x86_64/bin:/usr/local/cuda/bin:${PATH}
 export LD_LIBRARY_PATH=/usr/local/cuda/lib64:${LD_LIBRARY_PATH}

--- a/building/Rocky9/rocky9_build.md
+++ b/building/Rocky9/rocky9_build.md
@@ -93,24 +93,23 @@ The procedures of building MoonRay container with Apptainer and Rocky Linux 9 im
 3. Build MoonRay container with Apptainer
 
 ```bash
-git clone -b openmoonray-1.3.0.0 https://github.com/dreamworksanimation/openmoonray.git
-cp NVIDIA-OptiX-SDK-7.3.0-linux64-x86_64.sh openmoonray/building
-cd openmoonray/building
-apptainer build moonray.sif apptainer.def
+git clone --recurse-submodules https://github.com/dreamworksanimation/openmoonray.git
+export WORKDIR=$(pwd)
+bash openmoonray/building/Apptainer/build.sh
 ```
 
 To test MoonRay container
 
 ```bash
-apptainer run moonray.sif bash
-MoonRay> moonray -in /source/testdata/rectangle.rdla -out /tmp/rectangle.exr
-MoonRay> moonray_gui -in /source/testdata/rectangle.rdla -out /tmp/rectangle.exr
+apptainer run moonray.sif
+MoonRay> moonray -in /installs/testdata/rectangle.rdla -out /tmp/rectangle.exr
+MoonRay> moonray_gui -in /installs/testdata/rectangle.rdla -out /tmp/rectangle.exr
 ```
 
 To use MoonRay container with NVIDIA GPU
 
 ```bash
-apptainer run --nv moonray.sif bash
-MoonRay> moonray -in /source/testdata/rectangle.rdla -out /tmp/rectangle.exr
-MoonRay> moonray_gui -exec_mode xpu -in /source/testdata/rectangle.rdla -out /tmp/rectangle.exr
+apptainer run --nv moonray.sif
+MoonRay> moonray -in /installs/testdata/rectangle.rdla -out /tmp/rectangle.exr
+MoonRay> moonray_gui -exec_mode xpu -in /installs/testdata/rectangle.rdla -out /tmp/rectangle.exr
 ```

--- a/building/Rocky9/rocky9_build.md
+++ b/building/Rocky9/rocky9_build.md
@@ -72,7 +72,7 @@ More of the dependencies have a suitable version as part of Rocky 9, and so can 
 
 ***blosc boost lua openvdb tbb log4cplus cppunit libmicrohttpd***
 
-The ***libcgroup*** package is not available in Rocky 9 : *install_packages.sh* fetches it from another source (*kojihub.stream.centos.org*).
+The ***libcgroup*** package installation is not required on Rocky Linux 9 environment.
 
 Python 3.9 and Boost 1.75 come from Rocky 9. This changes a couple of things that were hard-coded into the main CMake build:
 - the name of the Python executable is "python3" (it is "python" in the Centos 7 build)
@@ -80,4 +80,37 @@ Python 3.9 and Boost 1.75 come from Rocky 9. This changes a couple of things tha
 
 As you can see in the main CMake command, these are now settable from the command line.
 
-There are a few very minor changes to the MoonRay source to enable it to compile with GCC 11 and Qt 5.15.3. In addition, the code must be built with C++ ABI version 0, rather than the value 6 used for the Centos 7 build. 
+There are a few very minor changes to the MoonRay source to enable it to compile with GCC 11 and Qt 5.15.3. In addition, the code must be built with C++ ABI version 0, rather than the value 6 used for the Centos 7 build.
+
+---
+## Building MoonRay Container with Apptainer and Rocky Linux 9 Image
+---
+
+The procedures of building MoonRay container with Apptainer and Rocky Linux 9 image is the following:
+
+1. Clone this repository
+2. Copy OptiX install script
+3. Build MoonRay container with Apptainer
+
+```bash
+git clone -b openmoonray-1.3.0.0 https://github.com/dreamworksanimation/openmoonray.git
+cp NVIDIA-OptiX-SDK-7.3.0-linux64-x86_64.sh openmoonray/building
+cd openmoonray/building
+apptainer build moonray.sif apptainer.def
+```
+
+To test MoonRay container
+
+```bash
+apptainer run moonray.sif bash
+MoonRay> moonray -in /source/testdata/rectangle.rdla -out /tmp/rectangle.exr
+MoonRay> moonray_gui -in /source/testdata/rectangle.rdla -out /tmp/rectangle.exr
+```
+
+To use MoonRay container with NVIDIA GPU
+
+```bash
+apptainer run --nv moonray.sif bash
+MoonRay> moonray -in /source/testdata/rectangle.rdla -out /tmp/rectangle.exr
+MoonRay> moonray_gui -exec_mode xpu -in /source/testdata/rectangle.rdla -out /tmp/rectangle.exr
+```

--- a/building/Rocky9/rocky9_build.md
+++ b/building/Rocky9/rocky9_build.md
@@ -72,7 +72,7 @@ More of the dependencies have a suitable version as part of Rocky 9, and so can 
 
 ***blosc boost lua openvdb tbb log4cplus cppunit libmicrohttpd***
 
-The ***libcgroup*** package installation is not required on Rocky Linux 9 environment.
+The ***libcgroup*** package installation is not mandatory from this version.
 
 Python 3.9 and Boost 1.75 come from Rocky 9. This changes a couple of things that were hard-coded into the main CMake build:
 - the name of the Python executable is "python3" (it is "python" in the Centos 7 build)

--- a/building/apptainer.def
+++ b/building/apptainer.def
@@ -1,0 +1,49 @@
+Bootstrap: docker
+From: rockylinux/rockylinux:9.2
+
+%setup
+    mkdir -p ${APPTAINER_ROOTFS}/source/building
+
+%files
+    Rocky9 /source/building
+    NVIDIA-OptiX-SDK-7.3.0-linux64-x86_64.sh /source/building/Rocky9/optix.sh
+
+%post
+    # Step 1: Base Requiements
+    source /source/building/Rocky9/install_packages.sh
+
+    # Step 2: Build Remaining Dependencies
+    mkdir /build
+    cd /build
+    cmake /source/building/Rocky9
+    cmake --build . -- -j $(nproc)
+
+    # Step 2 (optional): Install OptiX
+    bash /source/building/Rocky9/optix.sh --prefix=/usr/local --skip-license
+
+    # Step 3: Build MoonRay 
+    cd /build
+    rm -rf *
+    cd /source
+    git clone -b openmoonray-1.3.0.0 --recurse-submodules https://github.com/dreamworksanimation/openmoonray.git
+    cd /build
+    cmake /source/openmoonray \
+      -DPYTHON_EXECUTABLE=python3 -DBOOST_PYTHON_COMPONENT_NAME=python39 -DABI_VERSION=0
+    cmake --build . -j $(nproc)
+    mkdir -p /installs/openmoonray
+    cmake --install . --prefix /installs/openmoonray
+    
+    # Final Step: Move shader_json directory to writable location
+    cd /installs/openmoonray
+    sed -i 's@rel_root=${sourcedir}/..@rel_root=/installs/openmoonray@' scripts/setup.sh
+    sed -i 's@${rel_root}/shader_json@/tmp/shader_json@' scripts/setup.sh
+
+%environment
+    export PS1="MoonRay> "
+    
+%runscript
+    export LC_ALL=C; unset LANGUAGE
+    export PYTHONPATH=/usr/local/lib/python
+    ulimit -n 8192
+    source /installs/openmoonray/scripts/setup.sh
+    "$@"


### PR DESCRIPTION
Apptainer definition files for building MoonRay on Rocky Linux 9
Build procedures for building MoonRay container with Apptainer
Remove libcgroup package from Rocky Linux 9 installation script
Signed-off-by: Yoshiaki Senda <yoshiaki@live.it>