### PR TITLE
Ensure -pthread compiler flag isn't applied to all targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,11 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
+# Make sure we disable CMake from implicitly adding -pthread to all targets, this
+# is problematic because ISPC targets will inherit this flag incorrectly and will
+# error and not compile. Targets which do need this flag eg. GCC are explicitly set.
+set(THREADS_HAVE_PTHREAD_ARG FALSE)
+
 # ================================================
 # Subdirectories
 # ================================================


### PR DESCRIPTION
This prevents ISPC targets from getting a -pthread on the end of ISPC_FLAGS and erroring when compiling.

I am not sure what combination of distribution/compiler/versions that I am running into for this to happen, it could be CMake 3.27 which might be where this is coming from.